### PR TITLE
Fixed a problem with how hashcash is checked. The current version onl…

### DIFF
--- a/hashcashgen.js
+++ b/hashcashgen.js
@@ -52,7 +52,7 @@ exports.check = function checkHashCash (challenge, strength, hashcash, search) {
     strength || (strength = default_strength);
   }
   if (!search) search = repeat('0', strength);
-  return (hashcash.indexOf(challenge) === 0 && sha1(hashcash).indexOf(search) === 0);
+  return (hashcash.startsWith(challenge) && sha1(hashcash).startsWith(search));
 };
 
 function repeat (input, length) {


### PR DESCRIPTION
…y checks to see if the first character in the submission and resulting hash is correct. For example, if the sent hash was foo:808, and this resulted in 0fe8a8bc8 (it doesn't but let's pretend here), and the strength was two, this would pass ANYWAY, because only the first character is checked. Also, say the string used to hash sent to the client is 'foo'. Again, only the first character is checked, so the client could sent back 'fasdk3hau' and it would pass, even though it's wrong. This quick fix makes sure none of the above situations can happen.